### PR TITLE
Upgrade reqwest to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["authy", "2FA", "two", "factor", "bindings"]
 categories = ["authentication", "web-programming::http-client"]
 
 [dependencies]
-reqwest = "0.7"
+reqwest = "0.9"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,8 @@
-use std::thread;
 use std::io::Read;
+use std::thread;
 use std::time::Duration;
 
-use reqwest::{self, StatusCode, Method, Url};
-use reqwest::header::Headers;
+use reqwest::{self, Method, StatusCode, Url};
 use serde_json::{self, Value};
 
 use error::AuthyError;
@@ -40,44 +39,74 @@ impl Client {
         Client {
             retry_count: 3,
             retry_wait: 250,
-            api_url: api_url.into(), 
+            api_url: api_url.into(),
             api_key: api_key.into(),
-            reqwest: reqwest::Client::new().expect("A reqwest client"),
+            reqwest: reqwest::Client::new(),
         }
     }
 
     /// Send a `get` request to the Authy service. This is intended to be used
     /// by the library and not the user.
-    pub fn get(&self, prefix: &str, path: &str, url_params: Option<Vec<(String, String)>>) -> Result<(Status, Value), AuthyError> {
-        self.request(Method::Get, self.url(prefix, path, url_params), None)
+    pub fn get(
+        &self,
+        prefix: &str,
+        path: &str,
+        url_params: Option<Vec<(String, String)>>,
+    ) -> Result<(Status, Value), AuthyError> {
+        self.request(Method::GET, self.url(prefix, path, url_params), None)
     }
 
     /// Send a `post` request to the Authy service. This is intended to be used
     /// by the library and not the user.
-    pub fn post(&self, prefix: &str, path: &str, url_params: Option<Vec<(String, String)>>, post_params: Option<Vec<(String, String)>>) -> Result<(Status, Value), AuthyError> {
-        self.request(Method::Post, self.url(prefix, path, url_params), post_params)
+    pub fn post(
+        &self,
+        prefix: &str,
+        path: &str,
+        url_params: Option<Vec<(String, String)>>,
+        post_params: Option<Vec<(String, String)>>,
+    ) -> Result<(Status, Value), AuthyError> {
+        self.request(
+            Method::POST,
+            self.url(prefix, path, url_params),
+            post_params,
+        )
     }
 
     fn url(&self, prefix: &str, path: &str, params: Option<Vec<(String, String)>>) -> Url {
-        let base = format!("{api_url}/{prefix}/json/{path}", 
-                           api_url = self.api_url,
-                           prefix = prefix,
-                           path = path);
+        let base = format!(
+            "{api_url}/{prefix}/json/{path}",
+            api_url = self.api_url,
+            prefix = prefix,
+            path = path
+        );
         match params {
             Some(params) => Url::parse_with_params(&base, params),
             None => Url::parse(&base),
-        }.expect("Url to be valid")
+        }
+        .expect("Url to be valid")
     }
 
-    fn request(&self, method: Method, url: Url, params: Option<Vec<(String, String)>>) -> Result<(Status, Value), AuthyError> {
+    fn request(
+        &self,
+        method: Method,
+        url: Url,
+        params: Option<Vec<(String, String)>>,
+    ) -> Result<(Status, Value), AuthyError> {
         let mut count = self.retry_count;
         loop {
             let url = url.clone();
-            let mut headers = Headers::new();
-            headers.set_raw("X-Authy-API-Key", self.api_key.clone());
             let mut res = match params.clone() {
-                Some(p) => self.reqwest.request(method.clone(), url)?.headers(headers).form(&p)?.send()?,
-                None => self.reqwest.request(method.clone(), url)?.headers(headers).send()?,
+                Some(p) => self
+                    .reqwest
+                    .request(method.clone(), url)
+                    .header("X-Authy-API-Key", self.api_key.clone())
+                    .form(&p)
+                    .send()?,
+                None => self
+                    .reqwest
+                    .request(method.clone(), url)
+                    .header("X-Authy-API-Key", self.api_key.clone())
+                    .send()?,
             };
 
             let mut body = String::new();
@@ -101,30 +130,36 @@ impl Client {
                     let status: Status = serde_json::from_value(value.clone())?;
 
                     match res.status() {
-                        StatusCode::Ok => return Ok((status, value)),
-                        StatusCode::BadRequest => return Err(AuthyError::BadRequest(status)),
-                        StatusCode::Unauthorized => return Err(AuthyError::UnauthorizedKey(status)),
-                        StatusCode::Forbidden => return Err(AuthyError::Forbidden(status)),
-                        StatusCode::TooManyRequests => return Err(AuthyError::TooManyRequests(status)),
-                        StatusCode::NotFound => return Err(AuthyError::UserNotFound(status)),
-                        StatusCode::InternalServerError => return Err(AuthyError::InternalServerError(status)),
-                        s => return Err(AuthyError::UnknownServerResponse(format!("Status code not covered in authy REST specification: {}", s))),
+                        StatusCode::OK => return Ok((status, value)),
+                        StatusCode::BAD_REQUEST => return Err(AuthyError::BadRequest(status)),
+                        StatusCode::UNAUTHORIZED => return Err(AuthyError::UnauthorizedKey(status)),
+                        StatusCode::FORBIDDEN => return Err(AuthyError::Forbidden(status)),
+                        StatusCode::TOO_MANY_REQUESTS => {
+                            return Err(AuthyError::TooManyRequests(status))
+                        }
+                        StatusCode::NOT_FOUND => return Err(AuthyError::UserNotFound(status)),
+                        StatusCode::INTERNAL_SERVER_ERROR => {
+                            return Err(AuthyError::InternalServerError(status))
+                        }
+                        s => {
+                            return Err(AuthyError::UnknownServerResponse(format!(
+                                "Status code not covered in authy REST specification: {}",
+                                s
+                            )))
+                        }
                     };
-                },
-                Err(_) => {
-                    match res.status() {
-                        StatusCode::ServiceUnavailable => {
-                            count -= 1;
-                            if count == 0 {
-                                return Err(AuthyError::ServiceUnavailable);
-                            }
-                            else {
-                                thread::sleep(Duration::from_millis(self.retry_wait.into()));
-                                continue;
-                            }
-                        },
-                        _ => return Err(AuthyError::InvalidServerResponse),
+                }
+                Err(_) => match res.status() {
+                    StatusCode::SERVICE_UNAVAILABLE => {
+                        count -= 1;
+                        if count == 0 {
+                            return Err(AuthyError::ServiceUnavailable);
+                        } else {
+                            thread::sleep(Duration::from_millis(self.retry_wait.into()));
+                            continue;
+                        }
                     }
+                    _ => return Err(AuthyError::InvalidServerResponse),
                 },
             };
         }


### PR DESCRIPTION
This crate has been failing to build on hosts using OpenSSL 1.1.1 due to dependencies in Reqwest. [This was fixed in version 0.9](https://github.com/seanmonstar/reqwest/issues/345), so I went ahead and updated it and made the changes to get this to work with reqwest's API changes. 