### PR TITLE
Fix verification PhoneStart struct

### DIFF
--- a/src/api/phone.rs
+++ b/src/api/phone.rs
@@ -28,8 +28,12 @@ pub struct PhoneInfo {
 /// Returned when initiating verification of a phone number.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PhoneStart {
-    pub is_ported: bool,
+    pub carrier: String,
     pub is_cellphone: bool,
+    pub message: String,
+    pub seconds_to_expire: u16,
+    pub uuid: Option<String>,
+    pub success: bool,
 }
 
 /// The contact type used when verifying a phone number

--- a/tests/api_phone.rs
+++ b/tests/api_phone.rs
@@ -29,7 +29,8 @@ mod phone {
         c.retry_count = 10;
         let (status, info) = phone::start(&c, ContactType::SMS, 54, "317-338-9302", None, None).expect("PhoneVerification");
         assert!(status.success);
-        assert!(! info.is_ported);
+        assert_eq!(info.carrier, "Google Voice");
+        assert_eq!(info.message, "Text message sent to +54 317-338-9302.");
     }
 
 


### PR DESCRIPTION
I was getting errors because the `is_ported` field does not appear to be returned by [the Authy API any more](https://www.twilio.com/docs/verify/api/verification#send-a-verification-code). 

It _is_ returned by the sandbox used by the unit tests, but I assume it has been removed from the production API. 

I went ahead and added in the other fields included in the above documentation link. 